### PR TITLE
[MINOR] Process local update operation through operation queue

### DIFF
--- a/services/et/src/main/java/edu/snu/cay/services/et/evaluator/impl/TableImpl.java
+++ b/services/et/src/main/java/edu/snu/cay/services/et/evaluator/impl/TableImpl.java
@@ -420,10 +420,10 @@ public final class TableImpl<K, V, U> implements Table<K, V, U> {
         tableComponents.getOwnershipCache().resolveExecutorWithLock(blockId);
 
     final Optional<String> remoteIdOptional = remoteIdWithLock.getKey();
+    // TODO #11: Optimize local access routine of update operation
     // since UPDATE is write operation, we cannot bypass operation queue even it's for local blocks
     final String targetExecutorId = remoteIdOptional.orElse(executorId);
     try {
-
       final DataOpResult<V> dataOpResult = new SingleKeyDataOpResult<>();
       // send operation to remote or local queue
       remoteAccessOpSender.sendSingleKeyOpToRemote(
@@ -467,6 +467,7 @@ public final class TableImpl<K, V, U> implements Table<K, V, U> {
       final Pair<Optional<String>, Lock> remoteIdWithLock =
           tableComponents.getOwnershipCache().resolveExecutorWithLock(blockId);
       final Optional<String> remoteIdOptional = remoteIdWithLock.getKey();
+      // TODO #11: Optimize local access routine of update operation
       // since UPDATE is write operation, we cannot bypass operation queue even it's for local blocks
       final String targetExecutorId = remoteIdOptional.orElse(executorId);
       try {


### PR DESCRIPTION
This PR fixes the data consistency problem in the PS-collocation mode of Dolphin-on-ET.
Especially LDA app fails with EOFException, since its model array's length varies in runtime.

ET allows bypassing of operation queue when the operation is for local blocks.
It's quite efficient, since it minimizes overheads in data access.

However, allowing bypass to _update_ operation has a problem, since this operation should be atomic. Without operation queueing, the operation is not guaranteed to be atomic.

This PR simply eliminates the problem by changing ET's update operation to use the remote access's routine also for local access.
However, it has unnecessary overheads in (de)serialization of key and update values, (and passing through loopback network interface; I have no idea about how much overhead it has.).
Let's optimize this part later, since it's not much critical.