### PR TITLE
[MINOR] Use reef-0.16.0 in ET package

### DIFF
--- a/services/et/pom.xml
+++ b/services/et/pom.xml
@@ -40,7 +40,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <reef.version>0.16.0-SNAPSHOT</reef.version>
+    <reef.version>0.16.0</reef.version>
     <cay.version>0.1-SNAPSHOT</cay.version>
     <htrace.version>3.0.4</htrace.version>
     <avro.version>1.7.7</avro.version>


### PR DESCRIPTION
This PR is to change ET to use the  0.16.0-release version of REEF, not snapshot.